### PR TITLE
fix(ci-cd-pipeline): fixing the inputs.runner in jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ fromJSON(inputs.runner) }}
+    runs-on: ${{ inputs.runner }}
     steps:
       - name: Setup and Install
         uses: ./actions/install

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "dev"]
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   install:
-    runs-on: ${{ fromJSON(inputs.runner) }}
+    runs-on: ${{ inputs.runner }}
     steps:
       - name: Setup and Install
         uses: ./actions/install


### PR DESCRIPTION
Fixes and closes #8 

###  Fix JSON Parsing Error in `runs-on`

This PR fixes an evaluation error caused by using `fromJSON` on a plain string input (`'ubuntu-latest'`). The `runs-on` field now directly uses `${{ inputs.runner }}` instead of `fromJSON(inputs.runner)` in both `install.yml` and `build.yml`.

### Additional Update

* Updated workflow triggers to include both `dev` and `main` branches for CI/CD execution.

### Summary

* Fixed: `runs-on` syntax issue.
* Improved: CI now runs on both `dev` and `main`.