### PR TITLE
Fix/ci cd : path fix for compose install action and some low hanging issues addressed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ jobs:
   build:
     runs-on: ${{ inputs.runner }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Setup and Install
         uses: ./actions/install
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup and Install
-        uses: ./actions/install
+        uses: ./.github/actions/install
 
       - name: Build
         run: bun run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,9 @@
 name: Deploy to GitHub Pages
 
-on: push
+on:
+  push:
+    branches: ["main", "dev"]
+  workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,6 @@
 name: Deploy to GitHub Pages
 
-on:
-  push:
-    branches: ["main", "dev"]
-  workflow_dispatch:
+on: push
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -11,5 +11,8 @@ jobs:
   install:
     runs-on: ${{ inputs.runner }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Setup and Install
         uses: ./.github/actions/install

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -12,4 +12,4 @@ jobs:
     runs-on: ${{ inputs.runner }}
     steps:
       - name: Setup and Install
-        uses: ./actions/install
+        uses: ./.github/actions/install


### PR DESCRIPTION
Fixed some location changes in ci-cd jobs
- The current `bun run build:all` throws error since `abis/tokens` don't include Tokens.json and in .gitignore we have `utils/address.js` is removed from .gitignore
-  Also for any changes we need `install, build job to run` which can be dealed with in future 