### PR TITLE
fix: agora faucet address

### DIFF
--- a/contracts/IAgoraFaucet.sol
+++ b/contracts/IAgoraFaucet.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.8.4;
  * @title IAgoraFaucet
  * @notice Interface for Agora test token faucet
  * @dev Provides testnet token distribution functionality
- * @custom:tatara 0xba804DF5c476E8EaeF87BF8085F295300ccE2a49
+ * @custom:tatara 0xd236c18D274E54FAccC3dd9DDA4b27965a73ee6C
  * @custom:tags testnet,faucet,utility
  */
 interface IAgoraFaucet {

--- a/contracts/utils/TataraAddresses.sol
+++ b/contracts/utils/TataraAddresses.sol
@@ -17,7 +17,7 @@ library TataraAddresses {
      * @return The IAgoraFaucet contract address
      */
     function getAgoraFaucetAddress() internal pure returns (address) {
-        return 0xba804DF5c476E8EaeF87BF8085F295300ccE2a49;
+        return 0xd236c18D274E54FAccC3dd9DDA4b27965a73ee6C;
     }
 
     /**


### PR DESCRIPTION
This pr fixes the `AgoraFaucet Address` with a newer implementation, as discussed with @omnifient

Previous: Agora Faucet not working 
Now : Working Agora faucet 

Test: 
```
cast send 0xd236c18D274E54FAccC3dd9DDA4b27965a73ee6C \
  "requestFunds(address)"$PUBLIC_KEY \
  --rpc-url $TATARA_RPC_URL \
  --private-key $PRIVATE_KEY
```